### PR TITLE
Add github action for continuous deployement to ornt on push to master.

### DIFF
--- a/.github/workflows/DC.yml
+++ b/.github/workflows/DC.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  deploy-to-ornt:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Add ssh key
+        run: ssh-add - <<< "${SSH_PRIVATE_KEY}"
+        env:
+          GPG_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Login to ornt
+        run: ssh kolb@ornt.biologie.hu-berlin.de
+      - name: Build and setup docker stack
+        run: make build && make setup
+      - name: Wait for container health
+        run: bash wait-for-healthy-container.sh airflow-scheduler 120


### PR DESCRIPTION
This PR fixes #11 by adding a github action that deploys to ornt via ssh.