### PR TITLE
Fix incidence pipeline

### DIFF
--- a/dags/database/migrations/migration_files/20211120_00_add_constraint_on_population_table.sql
+++ b/dags/database/migrations/migration_files/20211120_00_add_constraint_on_population_table.sql
@@ -1,0 +1,3 @@
+DELETE FROM censusdata.population;
+ALTER TABLE censusdata.population DROP CONSTRAINT population_pkey;
+ALTER TABLE censusdata.population ADD PRIMARY KEY (nuts, agegroup, sex, year);


### PR DESCRIPTION
Incidence pipeline passes locally which shows that there is nothing fundamentally broken. However, there is too much data in the cencusdata.population table which is a result of this table not having a proper primary key constraint. 

This PR adds a migration that drops all data from the population table and adds a proper primary key constraint.

Fix #64 