### PR TITLE
users table race condition workaround

### DIFF
--- a/services/airflow/dags/datenspende_vitaldata/data_update/download.py
+++ b/services/airflow/dags/datenspende_vitaldata/data_update/download.py
@@ -40,7 +40,7 @@ def load_files(*_):
                 parse_dates=False,
             ),
         }
-        for file in glob.glob("./dailies*.csv")
+        for file in sorted(glob.glob("./dailies*.csv"))
     }
 
     usersdata = {

--- a/services/airflow/dags/datenspende_vitaldata/test_integration_dag.py
+++ b/services/airflow/dags/datenspende_vitaldata/test_integration_dag.py
@@ -1,0 +1,40 @@
+from database import DBContext, query_all_elements
+from airflow.models import DagBag
+from datetime import date
+
+from dags.helpers.test_helpers import execute_dag
+
+
+def test_dag_loads_with_no_errors():
+    dag_bag = DagBag(include_examples=False)
+    dag_bag.process_file("dag.py")
+    assert len(dag_bag.import_errors) == 0
+
+
+def test_datenspende_dag_writes_correct_results_to_db(db_context: DBContext):
+    credentials = db_context["credentials"]
+
+    assert (
+        execute_dag(
+            "datenspende-vitaldata",
+            "2021-01-01",
+            {"TARGET_DB": credentials["database"], "URL": THRYVE_FTP_URL},
+        )
+        == 0
+    )
+    answers_from_db = query_all_elements(
+        db_context, "SELECT * FROM datenspende.vitaldata"
+    )
+    assert answers_from_db[-1] == (
+        200,
+        date(2021, 10, 21),
+        65,
+        70,
+        6,
+        1635228999300,
+        120,
+    )
+    assert len(answers_from_db) == 10
+
+
+THRYVE_FTP_URL = "http://static-files/thryve/export.7z"


### PR DESCRIPTION
Currently datenspende as well as datenspende_vitaldata DAG update the users table, leading to a locked table. This PR introduces a workaround that makes the vitaldata DAG wait until the other one completes. It also adds an integration test to the vitaldata DAG.