### PR TITLE
Change datenspende dag names.

### DIFF
--- a/services/airflow/dags/datenspende/answers_post_processing/test_post_processing.py
+++ b/services/airflow/dags/datenspende/answers_post_processing/test_post_processing.py
@@ -13,7 +13,7 @@ from .post_processing import (
 
 def test_post_processing_loads_correct_answers(db_context: DBContext):
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )
@@ -31,7 +31,7 @@ def test_transform_answers_returns_elements_as_list():
 
 def test_etl_writes_to_db_correctly(db_context: DBContext):
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )

--- a/services/airflow/dags/datenspende/case_detection_features/extract/test_extract_survey_data.py
+++ b/services/airflow/dags/datenspende/case_detection_features/extract/test_extract_survey_data.py
@@ -59,7 +59,7 @@ def test_extract_features_from_weekly_questionnarie(prepared_db):
 @pytest.fixture
 def prepared_db(db_context: DBContext):
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )

--- a/services/airflow/dags/datenspende/case_detection_features/test_construct_features_task.py
+++ b/services/airflow/dags/datenspende/case_detection_features/test_construct_features_task.py
@@ -14,7 +14,7 @@ def test_feature_task_on_one_off_survey_results(db_context: DBContext):
 
     # fill database
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )
@@ -64,7 +64,7 @@ def test_feature_task_on_weeekly_survey_results(db_context: DBContext):
 
     # fill database
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )

--- a/services/airflow/dags/datenspende/case_detection_features/transform/test_transform_features.py
+++ b/services/airflow/dags/datenspende/case_detection_features/transform/test_transform_features.py
@@ -220,7 +220,7 @@ def test_get_symptom_ids_from_db(prepared_db):
 @pytest.fixture
 def prepared_db(db_context: DBContext):
     run_task_with_url(
-        "datenspende",
+        "datenspende_surveys_v2",
         "gather_data_from_thryve",
         "http://static-files/thryve/exportStudy.7z",
     )

--- a/services/airflow/dags/datenspende/dag.py
+++ b/services/airflow/dags/datenspende/dag.py
@@ -28,7 +28,7 @@ default_args = {
 }
 
 dag = DAG(
-    "datenspende",
+    "datenspende_surveys_v2",
     default_args=default_args,
     description="ETL study data from thryve",
     schedule_interval=timedelta(days=1),

--- a/services/airflow/dags/datenspende/test_integration_dag.py
+++ b/services/airflow/dags/datenspende/test_integration_dag.py
@@ -17,7 +17,7 @@ def test_datenspende_dag_writes_correct_results_to_db(db_context: DBContext):
 
     assert (
         execute_dag(
-            "datenspende",
+            "datenspende_surveys_v2",
             "2021-01-01",
             {"TARGET_DB": credentials["database"], "URL": THRYVE_FTP_URL},
         )

--- a/services/airflow/dags/datenspende_vitaldata/dag.py
+++ b/services/airflow/dags/datenspende_vitaldata/dag.py
@@ -25,7 +25,7 @@ default_args = {
 }
 
 dag = DAG(
-    "datenspende-vitaldata",
+    "datenspende_vitaldata_v2",
     default_args=default_args,
     description="ETL vital data from thryve",
     schedule_interval=timedelta(days=1),
@@ -38,7 +38,7 @@ dag = DAG(
 
 externalsensor1 = ExternalTaskSensor(
     task_id="dag_datenspende_completed_status",
-    external_dag_id="datenspende",
+    external_dag_id="datenspende_surveys_v2",
     external_task_id=None,  # wait for whole datenspende DAG to complete
     check_existence=True,
     timeout=1200,

--- a/services/airflow/dags/datenspende_vitaldata/test_integration_dag.py
+++ b/services/airflow/dags/datenspende_vitaldata/test_integration_dag.py
@@ -16,7 +16,7 @@ def test_datenspende_dag_writes_correct_results_to_db(db_context: DBContext):
 
     assert (
         execute_dag(
-            "datenspende-vitaldata",
+            "datenspende_vitaldata_v2",
             "2021-01-01",
             {"TARGET_DB": credentials["database"], "URL": THRYVE_FTP_URL},
         )

--- a/services/airflow/dags/helpers/test_helpers/helpers.py
+++ b/services/airflow/dags/helpers/test_helpers/helpers.py
@@ -102,7 +102,6 @@ def create_task_instance(dag_id: str, task_id: str, url: str = None):
 
 
 def run_task_with_url(dag_id: str, task_id: str, url: str):
-
     task, task_instance = create_task_instance(dag_id, task_id, url)
 
     task_instance.get_template_context()


### PR DESCRIPTION
Fix #104 

Schedule times don't update even though parameters in the dags are changed. Apparently, this is not a bug but a feature and if one wants to actually update the schedule, one has to change the dag name (ref. [here](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=62694614))