### PR TITLE
Add retries to download hospitalization data.

### DIFF
--- a/services/airflow/src/dags/update_hospitalizations/download_hospitalizations.py
+++ b/services/airflow/src/dags/update_hospitalizations/download_hospitalizations.py
@@ -1,5 +1,17 @@
 import pandas as pd
+from time import sleep
 
 
 def download_hospitalizations(url):
-    return pd.read_csv(url)
+    downloaded = False
+    retries = 0
+    while downloaded is False:
+        try:
+            data = pd.read_csv(url)
+            downloaded = True
+        except ConnectionResetError:
+            sleep(60)
+            retries += 1
+            if retries > 100:
+                raise TimeoutError("retried connecting 100 times without success.")
+    return data


### PR DESCRIPTION
Connection reset by peer is most likely a result of the server hosting the data experiencing too much load and then terminating the connection. This PR introduces retries for the download up to 100 times with a waiting period of 1 minute. I know, this is debugging in production and I don't like it but reproducing the intermittent behavior of an external server for testing is imo not feasible here.

Fix #134 