### PR TITLE
Add task to calculate mean and std of per user vitals in vital data post processing.

### DIFF
--- a/.github/workflows/lib_postgres_helpers_jobs.yml
+++ b/.github/workflows/lib_postgres_helpers_jobs.yml
@@ -7,10 +7,10 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-    paths: ["libraries/postgres_helpers/**"]
+    paths: ["libraries/postgres-helpers/**"]
   pull_request:
     branches: [ main ]
-    paths: ["libraries/postgres_helpers/**"]
+    paths: ["libraries/postgres-helpers/**"]
 
 
   # Allows you to run this workflow manually from the Actions tab

--- a/libraries/clickhouse-helpers/Makefile
+++ b/libraries/clickhouse-helpers/Makefile
@@ -3,7 +3,7 @@ include .env
 export $(shell sed 's/=.*//' .env)
 
 setup:
-	docker-compose up -d && bash wait-for-healthy-container.sh clickhouse-db-testing 300
+	docker-compose up -d && bash wait-for-healthy-container.sh clickhouse-db-testing 30
 
 down:
 	docker-compose down -v

--- a/libraries/clickhouse-helpers/clickhouse_helpers/db_context/db_test_context.py
+++ b/libraries/clickhouse-helpers/clickhouse_helpers/db_context/db_test_context.py
@@ -26,7 +26,7 @@ def db_context():
     yield context
 
     os.environ["CLICKHOUSE_DB"] = main_db
-    # teardown_test_db_context(context)
+    teardown_test_db_context(context)
 
 
 def teardown_test_db_context(context: DBContext) -> DBContext:

--- a/libraries/postgres-helpers/Makefile
+++ b/libraries/postgres-helpers/Makefile
@@ -6,7 +6,7 @@ build:
 	 DOCKER_BUILDKIT=1 docker-compose build
 
 setup:
-	docker-compose up -d
+	docker-compose up -d && bash wait-for-healthy-container.sh db 30
 
 down:
 	docker-compose down -v

--- a/libraries/postgres-helpers/postgres_helpers/migrations/migration_files/20220315_00_add_daily_vitals_statistics_table.sql
+++ b/libraries/postgres-helpers/postgres_helpers/migrations/migration_files/20220315_00_add_daily_vitals_statistics_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE datenspende_derivatives.daily_vital_statistics (
+    user_id INT,
+    type SMALLINT,
+    source SMALLINT,
+    std FLOAT,
+    mean FLOAT,
+    CONSTRAINT one_value_per_user_and_type PRIMARY KEY (user_id, type)
+);

--- a/libraries/postgres-helpers/wait-for-healthy-container.sh
+++ b/libraries/postgres-helpers/wait-for-healthy-container.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# taken from https://github.com/jordyv/wait-for-healthy-container
+# Licensed by Jordy Versmissen under the MIT Licence.
+
+container_name=$1
+shift
+timeout=$1
+
+default_timeout=120
+
+if [ -z ${timeout} ]; then
+    timeout=${default_timeout}
+fi
+
+RETURN_HEALTHY=0
+RETURN_STARTING=1
+RETURN_UNHEALTHY=2
+RETURN_UNKNOWN=3
+RETURN_ERROR=99
+
+function get_health_state {
+    state=$(docker inspect -f '{{ .State.Health.Status }}' ${container_name})
+    return_code=$?
+    if [ ! ${return_code} -eq 0 ]; then
+        exit ${RETURN_ERROR}
+    fi
+    if [[ "${state}" == "healthy" ]]; then
+        return ${RETURN_HEALTHY}
+    elif [[ "${state}" == "unhealthy" ]]; then
+        return ${RETURN_UNHEALTHY}
+    elif [[ "${state}" == "starting" ]]; then
+        return ${RETURN_STARTING}
+    else
+        return ${RETURN_UNKNOWN}
+    fi
+}
+
+function wait_for() {
+    echo "Wait for container '$container_name' to be healthy for max $timeout seconds..."
+    for i in `seq ${timeout}`; do
+        get_health_state
+        state=$?
+        if [ ${state} -eq 0 ]; then
+            echo "Container is healthy after ${i} seconds."
+            exit 0
+        fi
+        sleep 1
+    done
+
+    echo "Timeout exceeded. Health status returned: $(docker inspect -f '{{ .State.Health.Status }}' ${container_name})"
+    exit 1
+}
+
+if [ -z ${container_name} ]; then
+    usage
+    exit 1
+else
+    wait_for
+fi

--- a/services/airflow/pyproject.toml
+++ b/services/airflow/pyproject.toml
@@ -24,7 +24,7 @@ SQLAlchemy = "1.3.24"  # We have to pin this dependency, otherwise deleting dags
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"
-black = '^22' # according to https://github.com/peterjc/flake8-black#python-package-management
+black = '^22'
 pytest = "^6.2.4"
 testfixtures = "^6.17.1"
 pytest-xdist = "^2.3.0"

--- a/services/airflow/src/dags/datenspende_vitaldata/dag.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/dag.py
@@ -10,6 +10,7 @@ from src.dags.datenspende_vitaldata.data_update import (
 from src.dags.datenspende_vitaldata.post_processing import (
     pivot_vitaldata,
     PIVOT_TARGETS,
+    pipeline_for_aggregate_statistics_of_per_user_vitals,
 )
 
 from src.lib.dag_helpers import (
@@ -56,4 +57,10 @@ t2 = PythonOperator(
     op_args=PIVOT_TARGETS,
 )
 
-t1 >> t2
+t3 = PythonOperator(
+    task_id="calculate_aggregate_per_user_statistics_of_daily_vitals",
+    python_callable=pipeline_for_aggregate_statistics_of_per_user_vitals,
+    dag=dag,
+)
+
+t1 >> [t2, t3]

--- a/services/airflow/src/dags/datenspende_vitaldata/post_processing/__init__.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/post_processing/__init__.py
@@ -1,3 +1,8 @@
 from .pivot_tables import pivot_vitaldata, PIVOT_TARGETS
+from .aggregate_statistics import pipeline_for_aggregate_statistics_of_per_user_vitals
 
-__all__ = ["pivot_vitaldata", "PIVOT_TARGETS"]
+__all__ = [
+    "pivot_vitaldata",
+    "PIVOT_TARGETS",
+    "pipeline_for_aggregate_statistics_of_per_user_vitals",
+]

--- a/services/airflow/src/dags/datenspende_vitaldata/post_processing/aggregate_statistics.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/post_processing/aggregate_statistics.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import ramda as R
+from psycopg2.sql import SQL, Literal
+
+from postgres_helpers import create_db_context, teardown_db_context, DBContext
+from src.lib.test_helpers import set_env_variable_from_dag_config_if_present
+from src.lib.dag_helpers import (
+    execute_query_and_return_dataframe,
+    upsert_pandas_dataframe_to_table_in_schema_with_db_context,
+)
+
+DB_PARAMETERS = [
+    "datenspende_derivatives",
+    "daily_vital_statistics",
+    ["one_value_per_user_and_type"],
+]
+
+
+def pipeline_for_aggregate_statistics_of_per_user_vitals(**kwargs) -> None:
+    set_env_variable_from_dag_config_if_present("TARGET_DB", kwargs)
+    db_context = create_db_context()
+    R.map(
+        R.pipe(
+            calculate_aggregated_statistics_of_user_vitals,
+            upsert_pandas_dataframe_to_table_in_schema_with_db_context(
+                db_context, *DB_PARAMETERS
+            ),
+        ),
+        load_per_user_data(db_context),
+    )
+    teardown_db_context(db_context)
+
+
+def calculate_aggregated_statistics_of_user_vitals(
+    user_vital_data: pd.DataFrame,
+) -> pd.DataFrame:
+    return (
+        user_vital_data.groupby(["user_id", "type", "source"])
+        .agg({"value": ["mean", "std"]})
+        .droplevel(level=0, axis="columns")
+        .reset_index()
+    )
+
+
+def load_per_user_data(pg_context: DBContext) -> pd.DataFrame:
+    for user_id in load_distinct_user_ids(pg_context):
+        yield load_user_vitals(pg_context, user_id)
+
+
+def load_distinct_user_ids(db_context: DBContext) -> pd.DataFrame:
+    return R.pipe(
+        execute_query_and_return_dataframe(
+            SQL("SELECT DISTINCT user_id FROM datenspende.vitaldata;"),
+        ),
+        lambda df: df["user_id"].values,
+        R.map(int),
+    )(db_context)
+
+
+def load_user_vitals(db_context: DBContext, user_id: int) -> pd.DataFrame:
+    return execute_query_and_return_dataframe(
+        SQL(
+            "SELECT user_id, type, source, value FROM datenspende.vitaldata WHERE user_id={user_id}"
+        ).format(user_id=Literal(user_id)),
+        db_context,
+    )

--- a/services/airflow/src/dags/datenspende_vitaldata/post_processing/aggregate_statistics_test.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/post_processing/aggregate_statistics_test.py
@@ -1,0 +1,180 @@
+import numpy as np
+import pandas as pd
+
+from postgres_helpers import DBContext
+from src.lib.dag_helpers import execute_query_and_return_dataframe
+from .aggregate_statistics import (
+    load_per_user_data,
+    pipeline_for_aggregate_statistics_of_per_user_vitals,
+    calculate_aggregated_statistics_of_user_vitals,
+)
+from .test_pivot_tables import setup_vitaldata_in_db
+
+
+def test_integration_aggregate_statistics_pipeline(pg_context: DBContext):
+    setup_vitaldata_in_db()
+
+    pipeline_for_aggregate_statistics_of_per_user_vitals()
+    aggregate_statistics = execute_query_and_return_dataframe(
+        "SELECT * FROM datenspende_derivatives.daily_vital_statistics;", pg_context
+    )
+    assert (
+        aggregate_statistics.query("user_id == 100 and type == 9 and source == 6")[
+            "std"
+        ].values[0]
+        == 0
+    )
+    assert (
+        aggregate_statistics.query("user_id == 100 and type == 9 and source == 6")[
+            "mean"
+        ].values[0]
+        == pd.DataFrame(SECOND_TEST_USER_DATA)
+        .query("user_id == 100 and type == 9 and source == 6")["value"]
+        .mean()
+    )
+
+
+def test_load_per_user_data_loads_vitals_for_existing_users(pg_context: DBContext):
+    setup_vitaldata_in_db()
+
+    for user_data in load_per_user_data(pg_context):
+        assert isinstance(user_data, pd.DataFrame)
+        assert (
+            user_data.to_dict() == FIRST_TEST_USER_DATA
+            or user_data.to_dict() == SECOND_TEST_USER_DATA
+        )
+
+
+def test_calculate_aggregated_statistics_returns_nan_std_if_only_one_day_of_data_is_present():
+    assert np.isnan(
+        calculate_aggregated_statistics_of_user_vitals(
+            pd.DataFrame(FIRST_TEST_USER_DATA)
+        )["std"].values
+    ).all()
+
+
+def test_calculate_aggregated_statistics_returns_identity_for_mean_if_only_one_day_of_data_is_present():
+    assert (
+        calculate_aggregated_statistics_of_user_vitals(
+            pd.DataFrame(FIRST_TEST_USER_DATA).sort_values(
+                ["user_id", "type", "source"]
+            )
+        )["mean"].values
+        == pd.DataFrame(FIRST_TEST_USER_DATA)
+        .sort_values(["user_id", "type", "source"])["value"]
+        .values
+    ).all()
+
+
+def test_calculate_aggregated_statistics_returns_mean_and_std_for_more_than_one_day_of_data():
+    data = calculate_aggregated_statistics_of_user_vitals(
+        pd.DataFrame(SECOND_TEST_USER_DATA)
+    )
+    assert (
+        data.query("user_id == 100 and type == 9 and source == 6")["std"].values[0] == 0
+    )
+    assert (
+        data.query("user_id == 100 and type == 9 and source == 6")["mean"].values[0]
+        == pd.DataFrame(SECOND_TEST_USER_DATA)
+        .query("user_id == 100 and type == 9 and source == 6")["value"]
+        .mean()
+    )
+
+
+FIRST_TEST_USER_DATA = {
+    "user_id": {0: 200, 1: 200, 2: 200, 3: 200, 4: 200},
+    "type": {0: 9, 1: 65, 2: 43, 3: 52, 4: 53},
+    "source": {0: 6, 1: 6, 2: 6, 3: 6, 4: 6},
+    "value": {0: 3600, 1: 70, 2: 400, 3: 1634854000, 4: 1634879000},
+}
+
+SECOND_TEST_USER_DATA = {
+    "user_id": {
+        0: 100,
+        1: 100,
+        2: 100,
+        3: 100,
+        4: 100,
+        5: 100,
+        6: 100,
+        7: 100,
+        8: 100,
+        9: 100,
+        10: 100,
+        11: 100,
+        12: 100,
+        13: 100,
+        14: 100,
+    },
+    "type": {
+        0: 9,
+        1: 43,
+        2: 52,
+        3: 53,
+        4: 65,
+        5: 9,
+        6: 43,
+        7: 52,
+        8: 53,
+        9: 65,
+        10: 9,
+        11: 43,
+        12: 52,
+        13: 53,
+        14: 65,
+    },
+    "source": {
+        0: 6,
+        1: 3,
+        2: 3,
+        3: 3,
+        4: 3,
+        5: 6,
+        6: 3,
+        7: 3,
+        8: 3,
+        9: 3,
+        10: 6,
+        11: 3,
+        12: 3,
+        13: 3,
+        14: 3,
+    },
+    "value": {
+        0: 4600,
+        1: 500,
+        2: 1634936000,
+        3: 1634965000,
+        4: 50,
+        5: 4600,
+        6: 500,
+        7: 1634936000,
+        8: 1634965000,
+        9: 50,
+        10: 4600,
+        11: 500,
+        12: 1634936000,
+        13: 1634965000,
+        14: 50,
+    },
+}
+FIRST_TEST_USER_RESULT = {
+    "user_id": {0: 200, 1: 200, 2: 200, 3: 200, 4: 200},
+    "type": {0: 9, 1: 43, 2: 52, 3: 53, 4: 65},
+    "source": {0: 6, 1: 6, 2: 6, 3: 6, 4: 6},
+    "mean": {0: 3600.0, 1: 400.0, 2: 1634854000.0, 3: 1634879000.0, 4: 70.0},
+    "std": {
+        0: float("nan"),
+        1: float("nan"),
+        2: float("nan"),
+        3: float("nan"),
+        4: float("nan"),
+    },
+}
+SECOND_TEST_USER_RESULT = {
+    "user_id": {0: 100, 1: 100, 2: 100, 3: 100, 4: 100},
+    "type": {0: 9, 1: 43, 2: 52, 3: 53, 4: 65},
+    "source": {0: 6, 1: 3, 2: 3, 3: 3, 4: 3},
+    "mean": {0: 4600.0, 1: 500.0, 2: 1634936000.0, 3: 1634965000.0, 4: 50.0},
+    "std": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
+}

--- a/services/airflow/src/lib/dag_helpers/__init__.py
+++ b/services/airflow/src/lib/dag_helpers/__init__.py
@@ -7,6 +7,7 @@ from .write_dataframe_to_postgres import (
     connect_to_db_and_insert_polars_dataframe,
     connect_to_db_and_upsert_polars_dataframe,
     connect_to_db_and_upsert_pandas_dataframe_on_constraint,
+    upsert_pandas_dataframe_to_table_in_schema_with_db_context,
 )
 from .notify_slack import (
     create_slack_error_message_from_task_context,
@@ -28,4 +29,5 @@ __all__ = [
     "slack_notifier_factory",
     "create_slack_error_message_from_task_context",
     "execute_query_and_return_dataframe",
+    "upsert_pandas_dataframe_to_table_in_schema_with_db_context",
 ]

--- a/services/airflow/src/lib/dag_helpers/load_dataframe_from_postgres.py
+++ b/services/airflow/src/lib/dag_helpers/load_dataframe_from_postgres.py
@@ -1,8 +1,14 @@
-import ramda as R
+from typing import Union
+
 import pandas as pd
+import ramda as R
+from psycopg2.sql import SQL, Composed
+
 from postgres_helpers import DBContext
 
 
 @R.curry
-def execute_query_and_return_dataframe(query: str, context: DBContext):
+def execute_query_and_return_dataframe(
+    query: Union[str, SQL, Composed], context: DBContext
+):
     return pd.read_sql(query, con=context["connection"])

--- a/services/airflow/src/lib/dag_helpers/write_dataframe_to_postgres_test.py
+++ b/services/airflow/src/lib/dag_helpers/write_dataframe_to_postgres_test.py
@@ -1,12 +1,10 @@
-from typing import List
+from datetime import date, timedelta, datetime
 
 import numpy as np
 import pandas as pd
 import polars as po
-from datetime import date, timedelta, datetime
 
-import ramda as R
-
+from postgres_helpers import DBContext, query_all_elements, with_db_context
 from .write_dataframe_to_postgres import (
     _build_insert_query,
     _upsert_column_action,
@@ -15,14 +13,6 @@ from .write_dataframe_to_postgres import (
     connect_to_db_and_truncate_insert_pandas_dataframe,
     connect_to_db_and_insert_polars_dataframe,
     connect_to_db_and_upsert_pandas_dataframe,
-    build_upser_query_with_constraints,
-    _get_tuples_from_pd_dataframe,
-)
-from postgres_helpers import (
-    DBContext,
-    query_all_elements,
-    with_db_context,
-    execute_values,
 )
 
 

--- a/services/airflow/src/lib/dag_helpers/write_dataframe_to_postgres_test.py
+++ b/services/airflow/src/lib/dag_helpers/write_dataframe_to_postgres_test.py
@@ -1,7 +1,12 @@
+from typing import List
+
 import numpy as np
 import pandas as pd
 import polars as po
 from datetime import date, timedelta, datetime
+
+import ramda as R
+
 from .write_dataframe_to_postgres import (
     _build_insert_query,
     _upsert_column_action,
@@ -10,8 +15,15 @@ from .write_dataframe_to_postgres import (
     connect_to_db_and_truncate_insert_pandas_dataframe,
     connect_to_db_and_insert_polars_dataframe,
     connect_to_db_and_upsert_pandas_dataframe,
+    build_upser_query_with_constraints,
+    _get_tuples_from_pd_dataframe,
 )
-from postgres_helpers import DBContext, query_all_elements, with_db_context
+from postgres_helpers import (
+    DBContext,
+    query_all_elements,
+    with_db_context,
+    execute_values,
+)
 
 
 def test_insert_dataframe_to_postgres_works_with_polars_dataframe(
@@ -156,7 +168,7 @@ def test_upsert_dataframe_to_postgres_does_overwrite(pg_context: DBContext):
         schema="censusdata", table="nuts", data=DATA1
     )
     connect_to_db_and_upsert_pandas_dataframe(
-        schema="censusdata", table="nuts", constraint=["geo"], data=DATA2
+        schema="censusdata", table="nuts", constraint_columns=["geo"], data=DATA2
     )
     res = with_db_context(query_all_elements, "SELECT * FROM censusdata.nuts;")
     assert len(res) == 2


### PR DESCRIPTION
Calculate aggregate statistics that are necessary for per user z score standardization of vital sensor data. Calculating these aggregate statistics is slow and having it ready in the db will speed up ml prototyping.

values are in `datenspende_derivatives.daily_vital_statistics` and are updated as soon as new data is imported. They are calculated for each `user_id`, `type` and `source` such that standardized daily vitals can be pulled from the DB directly like 

```sql
SELECT 
    (vitals.value - statistics.mean)/statistics.std standardized_vitals, vitals.user_id, vitals.date, vitals.type, vitals.source
FROM
    datenspende.vitaldata vitals, datenspende_derivatives.daily_vital_statistics statistics
WHERE
    vitals.user_id = statistics.user_id AND
    vitals.type = statistics.type AND
    vitals.source = statistics.source
;
````