### PR TITLE
Wrap downloading functions in cleanup cwd wrapper

### DIFF
--- a/services/airflow/Makefile
+++ b/services/airflow/Makefile
@@ -27,7 +27,7 @@ watch:
 	docker exec -it airflow-scheduler pytest -f --ignore ./logs -k 'not integration'
 
 watchthis:
-	docker exec -it airflow-scheduler pytest -f --ignore ./logs -k $(TEST)
+	docker exec -it airflow-scheduler pytest -f --ignore ./logs -k $(test)
 
 postgres_migrations:
 	docker exec -w /opt/airflow/ airflow-scheduler poetry run yoyo apply --no-config-file --database postgresql://${TARGET_DB_USER}:${TARGET_DB_PW}@${TARGET_DB_HOSTNAME}/${TARGET_DB} ../../libraries/postgres-helpers/postgres_helpers/migrations/migration_files

--- a/services/airflow/airflow.cfg
+++ b/services/airflow/airflow.cfg
@@ -156,7 +156,7 @@ enable_xcom_pickling = False
 
 # When a task is killed forcefully, this is the amount of time in seconds that
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
-killed_task_cleanup_time = 60
+killed_task_cleanup_time = 6000
 
 # Whether to override params with dag_run.conf. If you pass some key-value pairs
 # through ``airflow dags backfill -c`` or

--- a/services/airflow/src/dags/datenspende/data_update/download.py
+++ b/services/airflow/src/dags/datenspende/data_update/download.py
@@ -1,13 +1,15 @@
-import polars
-import requests
-import py7zr
-import polars as po
-from polars.datatypes import Utf8, Int64
-import ramda as R
 from typing import List, Tuple
-from returns.curry import curry
-from requests.auth import HTTPBasicAuth
 
+import polars
+import polars as po
+import py7zr
+import ramda as R
+import requests
+from polars.datatypes import Utf8, Int64
+from requests.auth import HTTPBasicAuth
+from returns.curry import curry
+
+from src.lib.decorators import cwd_cleanup
 
 PolarsDataList = List[Tuple[str, polars.DataFrame]]
 
@@ -15,13 +17,16 @@ PolarsDataList = List[Tuple[str, polars.DataFrame]]
 DataList = PolarsDataList
 
 
+# TODO this is duplicate, refactor to remove with src.lib.dag_helpers.download_helpers.extract
 @R.curry
 def download(access_config: dict, url: str) -> PolarsDataList:
-    return R.pipe(
-        download_file(access_config),
-        unzip_file(access_config),
-        load_files,
-        map_dict_to_list,
+    return cwd_cleanup(
+        R.pipe(
+            download_file(access_config),
+            unzip_file(access_config),
+            load_files,
+            map_dict_to_list,
+        )
     )(url)
 
 

--- a/services/airflow/src/dags/datenspende_vitaldata/data_update/download.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/data_update/download.py
@@ -1,5 +1,6 @@
-import polars as po
 import glob
+
+import polars as po
 from polars.datatypes import Utf8, Int64
 
 from src.lib.dag_helpers.download_helpers import extract

--- a/services/airflow/src/dags/datenspende_vitaldata/data_update/test_upload.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/data_update/test_upload.py
@@ -1,6 +1,8 @@
-from postgres_helpers import DBContext, query_all_elements
 import os
+
 import ramda as R
+
+from postgres_helpers import DBContext, query_all_elements
 from .download import download
 from .transform import transform
 from .upload import upload

--- a/services/airflow/src/dags/datenspende_vitaldata/post_processing/shared.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/post_processing/shared.py
@@ -28,10 +28,12 @@ def post_processing_vitals_pipeline_factory(
         teardown_db_context(db_context)
 
         with Pool(worker_pool_size) as pool:
-            pool.map(
+            result = pool.map_async(
                 extract_process_load_vital_data_for_one_user(aggregator, db_parameters),
                 user_ids,
             )
+
+            result.wait()
 
     return pipeline
 

--- a/services/airflow/src/lib/dag_helpers/download_helpers.py
+++ b/services/airflow/src/lib/dag_helpers/download_helpers.py
@@ -9,6 +9,8 @@ from pandas import DataFrame, read_csv
 from requests.auth import HTTPBasicAuth
 from returns.curry import curry
 
+from src.lib.decorators import cwd_cleanup
+
 DataList = List[Tuple[str, List, polars.DataFrame]]
 
 
@@ -19,11 +21,14 @@ def extract(
     access_config: dict,
     url: str,
 ) -> DataList:
-    return R.pipe(
-        download_7zfile(access_config),
-        unzip_7zfile(access_config),
-        file_loader,
-        mapper,
+
+    return cwd_cleanup(
+        R.pipe(
+            download_7zfile(access_config),
+            unzip_7zfile(access_config),
+            file_loader,
+            mapper,
+        )
     )(url)
 
 

--- a/services/airflow/src/lib/decorators/__init__.py
+++ b/services/airflow/src/lib/decorators/__init__.py
@@ -1,0 +1,3 @@
+from .cwd_cleanup import cwd_cleanup
+
+__all__ = ["cwd_cleanup"]

--- a/services/airflow/src/lib/decorators/cwd_cleanup.py
+++ b/services/airflow/src/lib/decorators/cwd_cleanup.py
@@ -1,0 +1,25 @@
+import os
+import shutil
+import numpy as np
+
+
+def cwd_cleanup(func):
+    def inner(*args):
+        while True:
+            directory = "dir" + str(np.random.randint(10000, 99999))
+            try:
+                os.mkdir(directory)
+            except FileExistsError:
+                continue
+            break
+        os.chdir(directory)
+        try:
+            return_value = func(*args)
+        except Exception as error:
+            raise error
+        finally:
+            os.chdir("../")
+            shutil.rmtree(directory)
+        return return_value
+
+    return inner


### PR DESCRIPTION
 to avoid side effects via downloaded files in working directory.

Also, wait for workers when using a worker pool and increase timeout because Airflow will only wait for the main thread and kill everything else which leads to weird intermittent errors in integration tests.