### PR TITLE
fix deprecation warnings from Airflow

### DIFF
--- a/services/airflow/src/dags/corona_cases/dag.py
+++ b/services/airflow/src/dags/corona_cases/dag.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.sensors.external_task import ExternalTaskSensor
-from airflow.utils.dates import days_ago
+from pendulum import today
 from src.dags.corona_cases.cases import etl_covid_cases, CASES_ARGS
 from src.dags.corona_cases.incidences import (
     calculate_incidence_post_processing,
@@ -29,8 +29,8 @@ dag = DAG(
     "corona_cases",
     default_args=default_args,
     description="Download covid cases and calculate regional 7 day incidence values.",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(1),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-1),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/dags/csv_download_to_clickhouse/csv_download_to_clickhouse.py
+++ b/services/airflow/src/dags/csv_download_to_clickhouse/csv_download_to_clickhouse.py
@@ -4,7 +4,7 @@ import pandas as pd
 import ramda as R
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
+from pendulum import today
 from returns.curry import curry
 
 from clickhouse_helpers import (
@@ -52,8 +52,8 @@ dag = DAG(
     "extract_load_to_clickhouse",
     default_args=default_args,
     description="an example DAG that downloads a csv and uploads it to clickhouse",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(2),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-2),
     tags=["example"],
 )
 

--- a/services/airflow/src/dags/csv_download_to_postgres/csv_download_to_postgres.py
+++ b/services/airflow/src/dags/csv_download_to_postgres/csv_download_to_postgres.py
@@ -5,7 +5,7 @@ from returns.pipeline import pipe
 import ramda as R
 from datetime import timedelta
 from airflow import DAG
-from airflow.utils.dates import days_ago
+from pendulum import today
 from airflow.operators.python import PythonOperator
 from returns.curry import curry
 
@@ -78,8 +78,8 @@ dag = DAG(
     "example_csv_to_postgres",
     default_args=default_args,
     description="an example DAG that downloads a csv and uploads it to postgres",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(2),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-2),
     tags=["example"],
 )
 

--- a/services/airflow/src/dags/datenspende/dag.py
+++ b/services/airflow/src/dags/datenspende/dag.py
@@ -1,7 +1,7 @@
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from datetime import timedelta
-from airflow.utils.dates import days_ago
+from pendulum import today
 from src.dags.datenspende.data_update import data_update_etl, DATA_UPDATE_ARGS
 from src.dags.datenspende.answers_post_processing import (
     post_processing_test_and_symptoms_answers,
@@ -36,8 +36,8 @@ dag = DAG(
     "datenspende_surveys_v2",
     default_args=default_args,
     description="ETL study data from thryve",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(1, hour=1),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-1),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/dags/datenspende_epoch_data/dag.py
+++ b/services/airflow/src/dags/datenspende_epoch_data/dag.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
+from pendulum import today
 
 from src.dags.datenspende_epoch_data.data_update import (
     el_epoch_data,
@@ -26,8 +26,8 @@ dag = DAG(
     "datenspende_epoch_data_import_v1",
     default_args=default_args,
     description="ETL vital data from thryve",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(1, hour=2),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-1, hours=-2),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/dags/datenspende_vitaldata/dag.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/dag.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
+from pendulum import today
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.operators.bash import BashOperator
-from airflow.utils.dates import days_ago
 
 from src.dags.datenspende_vitaldata.data_update import (
     vital_data_update_etl,
@@ -33,8 +33,8 @@ dag = DAG(
     "datenspende_vitaldata_v2",
     default_args=default_args,
     description="ETL vital data from thryve",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(1, hour=2),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-1),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/dags/datenspende_vitaldata/dag_rolling_window.py
+++ b/services/airflow/src/dags/datenspende_vitaldata/dag_rolling_window.py
@@ -24,7 +24,7 @@ dag = DAG(
     "datenspende_vitaldata_rolling_window",
     default_args=default_args,
     description="rolling window features of vital data",
-    schedule_interval=timedelta(days=1),
+    schedule=timedelta(days=1),
     start_date=datetime(2021, 10, 1, 22),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(

--- a/services/airflow/src/dags/hello_world/hello_world.py
+++ b/services/airflow/src/dags/hello_world/hello_world.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
+from pendulum import today
 from src.lib.airflow_fp import (
     pull_execute_push,
     pull_execute,
@@ -35,8 +35,8 @@ dag = DAG(
     "hello_world_etl",
     default_args=default_args,
     description="A hello world DAG with dumy extract, transform and load tasks",
-    schedule_interval=timedelta(days=1),
-    start_date=days_ago(2),
+    schedule=timedelta(days=1),
+    start_date=today("UTC").add(days=-2),
     tags=["example"],
 )
 

--- a/services/airflow/src/dags/nuts_regions_population/dag.py
+++ b/services/airflow/src/dags/nuts_regions_population/dag.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.utils.dates import days_ago
+from pendulum import today
 from airflow.operators.python import PythonOperator
 
 from src.dags.nuts_regions_population.nuts_regions import (
@@ -39,7 +39,7 @@ dag = DAG(
     "nuts_regions_population",
     default_args=default_args,
     description="Load population data for NUTS 2021 regions from eurostat",
-    start_date=days_ago(1),
+    start_date=today("UTC").add(days=-1),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/dags/update_hospitalizations/dag.py
+++ b/services/airflow/src/dags/update_hospitalizations/dag.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.utils.dates import days_ago
+from pendulum import today
 from airflow.operators.python import PythonOperator
 
 from src.dags.update_hospitalizations.etl_hospitalizations import (
@@ -27,7 +27,7 @@ dag = DAG(
     "update_hospitalizations",
     default_args=default_args,
     description="Load icu admission rate hospitalization data from opendata",
-    start_date=days_ago(1),
+    start_date=today("UTC").add(days=-1),
     tags=["ROCS pipelines"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/lib/dag_helpers/test_notify_slack.py
+++ b/services/airflow/src/lib/dag_helpers/test_notify_slack.py
@@ -55,7 +55,7 @@ dag = DAG(
     DAG_ID,
     default_args=default_args,
     description="an example DAG that downloads a csv and uploads it to postgres",
-    start_date=today('UTC').add(days=-1),
+    start_date=today("UTC").add(days=-1),
     tags=["TEST DAG"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/lib/dag_helpers/test_notify_slack.py
+++ b/services/airflow/src/lib/dag_helpers/test_notify_slack.py
@@ -8,9 +8,9 @@ from src.lib.dag_helpers.notify_slack import (
 )
 
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from airflow.operators.python import PythonOperator
 from src.lib.test_helpers import get_task_context
+from pendulum import today
 
 
 @responses.activate
@@ -55,7 +55,7 @@ dag = DAG(
     DAG_ID,
     default_args=default_args,
     description="an example DAG that downloads a csv and uploads it to postgres",
-    start_date=days_ago(1),
+    start_date=today('UTC').add(days=-1),
     tags=["TEST DAG"],
     on_failure_callback=slack_notifier_factory(
         create_slack_error_message_from_task_context

--- a/services/airflow/src/lib/test_helpers/test_helpers.py
+++ b/services/airflow/src/lib/test_helpers/test_helpers.py
@@ -2,6 +2,7 @@ import os
 import ramda as R
 from airflow import DAG
 from airflow.operators.python import PythonOperator
+from pendulum import today
 
 from airflow.utils.dates import days_ago
 
@@ -24,7 +25,7 @@ task_id = "task_name"
 dag = DAG(
     dag_id,
     default_args=default_args,
-    start_date=days_ago(2),
+    start_date=today('UTC').add(days=-2),
     tags=["testing"],
 )
 PythonOperator(

--- a/services/airflow/src/lib/test_helpers/test_helpers.py
+++ b/services/airflow/src/lib/test_helpers/test_helpers.py
@@ -4,8 +4,6 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from pendulum import today
 
-from airflow.utils.dates import days_ago
-
 
 from src.lib.test_helpers.helpers import (
     check_if_var_exists_in_dag_conf,
@@ -25,7 +23,7 @@ task_id = "task_name"
 dag = DAG(
     dag_id,
     default_args=default_args,
-    start_date=today('UTC').add(days=-2),
+    start_date=today("UTC").add(days=-2),
     tags=["testing"],
 )
 PythonOperator(


### PR DESCRIPTION
I noticed I got >200 warnings, many from two to-be-deprecated names in Airflow

- days_ago which has been replaced with pendulum.today
- schedule_interval will be renamed to schedule

This small PR fixes the naming across our DAGs and support lib